### PR TITLE
Extended tern plugin

### DIFF
--- a/tern.js
+++ b/tern.js
@@ -10,7 +10,7 @@ define(function(require, exports, module) {
         var Plugin = imports.Plugin;
         var language = imports.language;
         
-        var plugin = new Plugin(" Ajax.org", main.consumes);
+        var plugin = new Plugin("Ajax.org", main.consumes);
         // var builtins = require("text!lib/tern_from_ts/sigs/__list.json");
         
         var defs = {};
@@ -50,62 +50,65 @@ define(function(require, exports, module) {
                     requirejs: "tern/plugin/requirejs",
                     architect_resolver: "./architect_resolver_worker"
                 },
-                defs: [
-                    {
-                        name: "ecma5",
-                        enabled: true,
-                        path: "lib/tern/defs/ecma5.json"
-                    },
-                    {
-                        name: "jQuery",
-                        enabled: true,
-                        path: "lib/tern/defs/jquery.json"
-                    },
-                    {
-                        name: "browser",
-                        enabled: true,
-                        path: "lib/tern/defs/browser.json"
-                    },
-                    {
-                        name: "underscore",
-                        enabled: false,
-                        path: "lib/tern/defs/underscore.json"
-                    },
-                    {
-                        name: "chai",
-                        enabled: false,
-                        path: "tern/defs/chai.json"
-                    }
-                ]
+                defs: [{
+                    name: "ecma5",
+                    enabled: true,
+                    path: "lib/tern/defs/ecma5.json"
+                }, {
+                    name: "jQuery",
+                    enabled: true,
+                    path: "lib/tern/defs/jquery.json"
+                }, {
+                    name: "browser",
+                    enabled: true,
+                    path: "lib/tern/defs/browser.json"
+                }, {
+                    name: "underscore",
+                    enabled: false,
+                    path: "lib/tern/defs/underscore.json"
+                }, {
+                    name: "chai",
+                    enabled: false,
+                    path: "tern/defs/chai.json"
+                }]
             };
-            
+
             ternPlugins(function callback(e) {
-                var pluginName, pluginPath;
-                for(pluginName in ternOptions.plugins) {
+                var pluginName;
+                var pluginPath;
+                for (pluginName in ternOptions.plugins) {
                     pluginPath = ternOptions.plugins[pluginName];
-                    e.push({name: pluginName, enabled: true, path: pluginPath});    
+                    e.push({
+                        name: pluginName,
+                        enabled: true,
+                        path: pluginPath
+                    });
                 }
             });
-            
-            
-            var defsToAdd =[], defIndex, d;
-            for(defIndex in ternOptions.defs) {
+
+
+            var defsToAdd = []
+            var defIndex;
+            var d;
+            for (defIndex in ternOptions.defs) {
                 d = ternOptions.defs[defIndex];
                 defs[d.name] = d.path;
-                if(d.enabled) {
+                if (d.enabled) {
                     defsToAdd.push(d.path);
                 }
             }
             language.getWorker(function(err, worker) {
                 if (err) return console.error(err);
-                worker.emit("tern_set_def_enabled", { data: {
-                    name: '',
-                    def: defsToAdd,
-                    enabled: true
-                }});
+                worker.emit("tern_set_def_enabled", {
+                    data: {
+                        name: "",
+                        def: defsToAdd,
+                        enabled: true
+                    }
+                });
             });
-        }
-        
+            }
+                    
         function registerDef(name, def, enable, hide) {
             defs[name] = def;
             if (!hide)
@@ -115,7 +118,7 @@ define(function(require, exports, module) {
         }
 
         function setDefEnabled(name, enabled) {
-            var defsDefinedByPlugin = ['angular', 'node', 'component', "requirejs"];
+            var defsDefinedByPlugin = ["angular", "node", "component", "requirejs"];
             if (!defs[name] && defsDefinedByPlugin.indexOf(name) === -1)
                 throw new Error("Definition " + name + " not found");
             
@@ -131,7 +134,7 @@ define(function(require, exports, module) {
         }
         
         function getTernDefNames(callback) {
-            if(typeof callback !== 'function') {return;}
+            if(typeof callback !== "function") {return;}
             language.getWorker(function(err, worker) {
                 if (err) return console.error(err);
                 worker.on("tern_read_def_names", function tern_read_def_names (e){
@@ -150,7 +153,7 @@ define(function(require, exports, module) {
         }
         
         function ternPlugins(callback) {
-            if(typeof callback !== 'function') {return;}
+            if(typeof callback !== "function") {return;}
             language.getWorker(function(err, worker) {
                 if (err) return console.error(err);
                 worker.on("tern_read_plugins", function tern_read_plugins (e){
@@ -188,6 +191,22 @@ define(function(require, exports, module) {
         
         plugin.freezePublicAPI({
             /**
+             * Callback function for getting tern definition list from directly tern server
+             * @typedef {Object} pluginInfo
+             * @property {String} name - name of the plugin
+             * @property {boolean} enabled - Setting it false marks plugin for removal
+             * @property {String} path - Parameter to provide while loading a new plugin
+             *
+             * This callback is to retrieve names of definitions
+             * @callback getTernDefNamesCallback
+             * @param {Array.String} names Array of names
+             *
+             * This callback is to retrieve plugin info
+             * @callback ternPluginsCallback
+             * @param {Array.pluginInfo} e list of plugins with status
+             */
+
+            /**
              * Add a tern definition that users can enable.
              * @param {String} name
              * @param {String|Object} def   The definition or a URL pointing to the definiton
@@ -210,33 +229,15 @@ define(function(require, exports, module) {
             
             /**
              * Gets list of loaded tern definition names
-             * @param {tern~getTernDefNamesCallback} callback required function to retrieve names
+             * @param {getTernDefNamesCallback} callback required function to retrieve names
              */
             getTernDefNames: getTernDefNames,
-            /**
-             * This callback is to retrieve names of definitions
-             * @callback tern~getTernDefNamesCallback
-             * @param {Array.String} names Array of names
-             */
-             
-             /**
-             * The complete Triforce, or one or more components of the Triforce.
-             * @typedef {Object} tern~pluginInfo
-             * @property {String} name - name of the plugin
-             * @property {boolean} enabled - Setting it false marks plugin for removal
-             * @property {String} path - Parameter to provide while loading a new plugin
-             */
              
              /**
               * Gets list of loaded tern plugins. When retrieved can disable plugins and add new ones
-              * @param {tern~ternPluginsCallback} callback required function to process status of plugins
+              * @param {ternPluginsCallback} callback required function to process status of plugins
               */
              ternPlugins: ternPlugins,
-             /**
-              * @callback tern~ternPluginsCallback
-              * @param {Array.tern~pluginInfo} e list of plugins with status
-              */
-             
             
             /**
              * Sets tern request options
@@ -246,8 +247,7 @@ define(function(require, exports, module) {
             
             /**
              * Get a list of all definitions.
-             * 
-             * @param {Boolean} Return only definitions to show in preferences.
+             * @param {Boolean} preferenceDefsOnly Return only definitions to show in preferences.
              * @return {String[]}
              */
             getDefs: getDefs

--- a/worker/tern_worker.js
+++ b/worker/tern_worker.js
@@ -53,7 +53,7 @@ function mix() {
     return child;
 }
 
-    
+
 handler.handlesLanguage = function(language) {
     // Note that we don't really support jsx here,
     // but rather tolerate it using error recovery...
@@ -82,19 +82,19 @@ handler.init = function(callback) {
             // TODO we can use file cache in navigate to find a folder for unresolved modules
             if (file[0] != "/")
                 file = "/" + file;
-                
+
             util.stat(file, function(err, stat) {
                 if (stat && stat.size > MAX_FILE_SIZE) {
                     err = new Error("File is too large to include");
                     err.code = "ESIZE";
                 }
-                
+
                 if (err)
                     return done(err);
 
                 fileCache[file] = fileCache[file] || {};
                 fileCache[file].mtime = stat.mtime;
-        
+
                 util.readFile(file, { allowUnsaved: true }, function(err, data) {
                     if (err) return done(err);
 
@@ -114,28 +114,28 @@ handler.init = function(callback) {
         }
     });
     inferCompleter.setExtraModules(ternWorker.cx.definitions.node);
-    
+
     ternWorker.on("beforeLoad", function(e) {
         var file = e.name;
         var dir = dirname(e.name);
-        
+
         if (dir[0] != "/")
             return;
-        
+
         if (!dirCache[dir])
             util.$watchDir(dir, handler);
-        
+
         fileCache[file] = fileCache[file] || {};
         dirCache[dir] = dirCache[dir] || {};
         dirCache[dir].used = Date.now();
         dirCache[dir][file] = true;
         lastCacheRead = Date.now();
     });
-    
+
     handler.sender.on("tern_set_def_enabled", function(e) {
         setDefEnabled(e.data.name, e.data.def, e.data.enabled);
     });
-    
+
     handler.sender.on("tern_set_server_options", function(e) {
         var target = ternWorker.options || ternServerOptions;
         var prop;
@@ -160,7 +160,7 @@ handler.init = function(callback) {
     });
 
     handler.sender.on("tern_get_plugins", function(e) {
-        var pluginName
+        var pluginName;
         var plugins = [];
         var pluginToList;
         for (pluginName in ternWorker.options.plugins) {
@@ -206,7 +206,7 @@ handler.init = function(callback) {
             ternWorker.reset();
         }
     });
-    
+
     util.$onWatchDirChange(onWatchDirChange);
     setInterval(garbageCollect, 60000);
     callback();
@@ -226,7 +226,7 @@ function onWatchDirChange(e) {
 
 function garbageCollect() {
     var minAge = lastCacheRead - MAX_CACHE_AGE;
-    
+
     for (var file in fileCache) {
         if (fileCache[file].used < minAge) {
             ternWorker.delFile(file);
@@ -235,7 +235,7 @@ function garbageCollect() {
                 lastAddPath = null;
         }
     }
-    
+
     for (var dir in dirCache) {
         if (dirCache[dir].used < minAge) {
             handler.sender.emit("unwatchDir", { path: dir });
@@ -276,7 +276,7 @@ handler.complete = function(doc, fullAst, pos, currentNode, callback) {
         return callback();
 
     addTernFile(this.path, doc.getValue());
-    
+
     var line = doc.getLine(pos.row);
     var prefix = util.getPrecedingIdentifier(line, pos.column);
     var defaultOptions = {
@@ -319,7 +319,7 @@ handler.complete = function(doc, fullAst, pos, currentNode, callback) {
                 match.name = match.name.replace(/"(.*)"/, "$1");
                 icon = "package";
             }
-                        
+
             var isFunction = match.type && match.type.match(/^fn\(/);
             var isAnonymous = match.type && match.type.match(/^{/);
             var fullName;
@@ -353,7 +353,8 @@ handler.complete = function(doc, fullAst, pos, currentNode, callback) {
                 isContextual: isContextual,
                 docHead: fullNameTyped,
                 doc: (match.origin && isFromLibrary ? "Origin: " + match.origin + "<p>" : "") + doc,
-                isFunction: isFunction
+                isFunction: isFunction,
+                url: match.url
             };
         }).filter(function(c) {
             return c;
@@ -458,15 +459,15 @@ handler.tooltip = function(doc, fullAst, cursorPos, currentNode, callback) {
     if (!currentNode)
         return callback();
     var argIndex = -1;
-    
+
     var callNode = getCallNode(currentNode, cursorPos);
     var displayPos;
-    
+
     if (callNode) {
-        var argPos = { row: callNode[1].getPos().sl, column: callNode[1].getPos().sc }; 
+        var argPos = { row: callNode[1].getPos().sl, column: callNode[1].getPos().sc };
         if (argPos.row >= 9999999999)
             argPos = cursorPos;
-      
+
         displayPos = argPos;
         argIndex = this.getArgIndex(callNode, doc, cursorPos);
     }
@@ -480,7 +481,7 @@ handler.tooltip = function(doc, fullAst, cursorPos, currentNode, callback) {
     else {
         return callback();
     }
-    
+
     if (argIndex === -1 && callNode)
         return callback();
 
@@ -699,7 +700,7 @@ function getSignature(property) {
         if (p.type)
             p.type = p.type.replace(/.*\./, "");
     });
-    
+
 
     if (parameters[0].name === "")
         parameters.shift();


### PR DESCRIPTION
Exposed some functionality in tern_worker via c9-plugin tern.
- Exposed adding & removing plugins.
- Exposed getting list of definitions loaded by tern_worker (instead of
  tern c9-plugin as a separate functionality)
- Improved adding multiple def performance (tern server resets once)
- Exposed changing tern server options
- Exposed changing tern request options
- It is possible to define default tern-plugins and defs via client-default. Current implementation does not require to client-default to be updated.
